### PR TITLE
fix: stop returning nulls

### DIFF
--- a/src/db2ia/dbstmt.cc
+++ b/src/db2ia/dbstmt.cc
@@ -2491,9 +2491,6 @@ int DbStmt::buildJsObject(Napi::Env env, Napi::Array *array)
             break;
           }
         default:
-          if (resultSetInC[row][col].rlength > 0)
-            value = Napi::String::New(env, resultSetInC[row][col].data, resultSetInC[row][col].rlength);
-          else
             value = Napi::String::New(env, resultSetInC[row][col].data);
           break;
         }


### PR DESCRIPTION
When returning a result set from RPGLE External SQL Stored Procedure, nulls are being returned in the fields that are returned.